### PR TITLE
Fix of fix/dockerignore-issue-59

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# Node.js
+frontend/node_modules
+frontend/.next
+frontend/out
+frontend/build
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Python
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Environment
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git
+.gitignore
+
+# Docker
+docker-compose.yml
+Dockerfile
+.dockerignore
+
+# IDE
+.vscode
+.idea


### PR DESCRIPTION
Implement a root-level `.dockerignore` file to explicitly exclude local dependency folders (`node_modules`, `.venv`), build artifacts (`.next`, `__pycache__`), and environment secrets (`.env`) from the Docker build context.

  Including following Tasks:
   - [x] Create .dockerignore at the repository root.
   - [x] Exclude frontend/node_modules/ and frontend/.next/.
   - [x] Exclude .venv/, __pycache__/, and .pytest_cache/.
   - [x] Exclude .env and .git/.
   - [x] Verify that docker compose build context size is significantly reduced.
   
   Closes of #59 