### PR TITLE
Feature: Doctor Recommendation Based on Symptoms (#33)

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -59,7 +59,8 @@ async def chat(
 
         symptoms = symptom_extractor.extract(normalized_message, request.symptoms)
         rule_based_analysis = triage_service.assess(symptoms)
-        recommended_specialist = doctor_service.recommend(symptoms)
+        doctor_recommendation = doctor_service.recommend_detailed(symptoms)
+        recommended_specialist = doctor_recommendation.specialist
 
         cache_key = chat_cache_key(normalized_message)
         cached = cache.get(cache_key)
@@ -74,6 +75,7 @@ async def chat(
                 symptom_analysis=rule_based_analysis,
                 detected_language=detected_language,
                 recommended_specialist=recommended_specialist,
+                doctor_recommendation=doctor_recommendation,
             )
 
         # Use enhanced RAG query with symptom analysis
@@ -115,6 +117,7 @@ async def chat(
             symptom_analysis=result.get("symptom_analysis") or rule_based_analysis,
             detected_language=detected_language,
             recommended_specialist=recommended_specialist,
+            doctor_recommendation=doctor_recommendation,
         )
 
     except HTTPException:
@@ -154,13 +157,15 @@ async def analyze_symptoms(
         )
         triage = triage_service.assess(symptoms)
 
+        doctor_recommendation = doctor_service.recommend_detailed(symptoms)
         return ChatResponse(
             response=result["response"],
             conversation_id=request.conversation_id or str(uuid.uuid4()),
             sources=result.get("sources", []),
             citations=result.get("citations", []),
             symptom_analysis=result.get("symptom_analysis") or triage,
-            recommended_specialist=doctor_service.recommend(symptoms),
+            recommended_specialist=doctor_recommendation.specialist,
+            doctor_recommendation=doctor_recommendation,
         )
 
     except HTTPException:

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -27,6 +27,12 @@ class ChatRequest(BaseModel):
     user_id: Optional[str] = None
     symptoms: Optional[List[str]] = None  # Explicit symptom list
 
+class DoctorRecommendation(BaseModel):
+    specialist: str
+    confidence: float  # 0.0 - 1.0
+    reasoning: str
+    alternative_specialists: List[str] = []
+
 class ChatResponse(BaseModel):
     response: str
     conversation_id: str
@@ -35,6 +41,7 @@ class ChatResponse(BaseModel):
     symptom_analysis: Optional[SymptomAnalysis] = None
     detected_language: Optional[str] = None
     recommended_specialist: Optional[str] = None
+    doctor_recommendation: Optional[DoctorRecommendation] = None
     disclaimer: str = "This is not medical advice. Please consult a healthcare professional for proper diagnosis and treatment."
 
 class Document(BaseModel):

--- a/backend/app/services/medical_intelligence_service.py
+++ b/backend/app/services/medical_intelligence_service.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
-from typing import List
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
 
-from ..models.chat import RiskLevel, SymptomAnalysis
+from ..models.chat import DoctorRecommendation, RiskLevel, SymptomAnalysis
 
 try:
     import spacy
@@ -76,16 +76,213 @@ class TriageService:
         )
 
 
+# Mapping of specialist to (symptom keywords, weight).
+# Weight reflects how strongly the keyword indicates that specialist.
+SPECIALIST_SYMPTOM_MAP: Dict[str, List[Tuple[str, float]]] = {
+    "Cardiologist": [
+        ("chest pain", 1.0),
+        ("heart palpitations", 1.0),
+        ("palpitations", 0.9),
+        ("irregular heartbeat", 1.0),
+        ("high blood pressure", 0.8),
+        ("shortness of breath", 0.6),
+        ("swollen ankles", 0.7),
+        ("chest tightness", 0.9),
+        ("heart", 0.7),
+    ],
+    "Dermatologist": [
+        ("skin rash", 1.0),
+        ("rash", 0.9),
+        ("acne", 1.0),
+        ("eczema", 1.0),
+        ("psoriasis", 1.0),
+        ("itchy skin", 0.9),
+        ("hives", 0.9),
+        ("skin lesion", 0.9),
+        ("mole", 0.8),
+        ("skin", 0.5),
+    ],
+    "Neurologist": [
+        ("severe headache", 1.0),
+        ("migraine", 1.0),
+        ("seizure", 1.0),
+        ("numbness", 0.8),
+        ("tingling", 0.8),
+        ("dizziness", 0.7),
+        ("tremor", 0.9),
+        ("memory loss", 0.8),
+        ("confusion", 0.7),
+        ("headache", 0.6),
+    ],
+    "Pulmonologist": [
+        ("chronic cough", 1.0),
+        ("wheezing", 1.0),
+        ("asthma", 1.0),
+        ("shortness of breath", 0.7),
+        ("coughing blood", 1.0),
+        ("breathing difficulty", 0.9),
+        ("persistent cough", 0.9),
+        ("cough", 0.5),
+    ],
+    "Gastroenterologist": [
+        ("abdominal pain", 1.0),
+        ("stomach pain", 0.9),
+        ("bloating", 0.8),
+        ("diarrhea", 0.8),
+        ("constipation", 0.8),
+        ("acid reflux", 1.0),
+        ("heartburn", 0.9),
+        ("nausea", 0.6),
+        ("vomiting", 0.7),
+        ("blood in stool", 1.0),
+    ],
+    "Orthopedist": [
+        ("joint pain", 1.0),
+        ("back pain", 1.0),
+        ("knee pain", 1.0),
+        ("fracture", 1.0),
+        ("bone pain", 0.9),
+        ("sprain", 0.9),
+        ("swollen joint", 0.9),
+        ("stiffness", 0.7),
+        ("muscle pain", 0.6),
+    ],
+    "ENT Specialist": [
+        ("ear pain", 1.0),
+        ("sore throat", 0.8),
+        ("hearing loss", 1.0),
+        ("tinnitus", 1.0),
+        ("nasal congestion", 0.8),
+        ("sinus pain", 0.9),
+        ("nosebleed", 0.8),
+        ("hoarseness", 0.8),
+        ("snoring", 0.7),
+    ],
+    "Ophthalmologist": [
+        ("blurred vision", 1.0),
+        ("eye pain", 1.0),
+        ("vision loss", 1.0),
+        ("red eye", 0.9),
+        ("eye infection", 1.0),
+        ("double vision", 1.0),
+        ("floaters", 0.8),
+    ],
+    "Endocrinologist": [
+        ("excessive thirst", 0.9),
+        ("frequent urination", 0.8),
+        ("weight gain", 0.7),
+        ("weight loss", 0.6),
+        ("thyroid", 1.0),
+        ("diabetes", 1.0),
+        ("hormonal imbalance", 1.0),
+        ("fatigue", 0.4),
+    ],
+    "Psychiatrist": [
+        ("anxiety", 1.0),
+        ("depression", 1.0),
+        ("insomnia", 0.8),
+        ("panic attack", 1.0),
+        ("mood swings", 0.9),
+        ("hallucinations", 1.0),
+        ("suicidal thoughts", 1.0),
+    ],
+    "Urologist": [
+        ("painful urination", 1.0),
+        ("blood in urine", 1.0),
+        ("frequent urination", 0.7),
+        ("kidney pain", 0.9),
+        ("urinary incontinence", 1.0),
+    ],
+    "Allergist": [
+        ("allergic reaction", 1.0),
+        ("allergy", 1.0),
+        ("sneezing", 0.7),
+        ("watery eyes", 0.7),
+        ("hives", 0.7),
+        ("swelling", 0.6),
+    ],
+    "Rheumatologist": [
+        ("joint swelling", 1.0),
+        ("arthritis", 1.0),
+        ("lupus", 1.0),
+        ("chronic fatigue", 0.7),
+        ("morning stiffness", 0.9),
+        ("joint pain", 0.6),
+    ],
+    "Pediatrician": [
+        ("child", 0.9),
+        ("children", 0.9),
+        ("infant", 1.0),
+        ("baby", 1.0),
+        ("toddler", 1.0),
+    ],
+}
+
+
 @dataclass
 class DoctorRecommendationService:
+    """Recommends a medical specialist based on symptom-to-specialist weighted mapping."""
+
+    _specialist_map: Dict[str, List[Tuple[str, float]]] = field(
+        default_factory=lambda: SPECIALIST_SYMPTOM_MAP
+    )
+
     def recommend(self, symptoms: List[str]) -> str:
+        """Return the top specialist name (backwards-compatible)."""
+        rec = self.recommend_detailed(symptoms)
+        return rec.specialist
+
+    def recommend_detailed(self, symptoms: List[str]) -> DoctorRecommendation:
+        """Return a structured recommendation with confidence and reasoning."""
+        if not symptoms:
+            return DoctorRecommendation(
+                specialist="General Physician",
+                confidence=0.5,
+                reasoning="No specific symptoms detected. A General Physician can perform an initial assessment.",
+            )
+
         joined = " ".join(symptoms).lower()
-        if "skin" in joined or "rash" in joined:
-            return "Dermatologist"
-        if "chest" in joined or "heart" in joined:
-            return "Cardiologist"
-        if "head" in joined or "dizziness" in joined:
-            return "Neurologist"
-        if "children" in joined:
-            return "Pediatrician"
-        return "General Physician"
+        scores: Dict[str, float] = {}
+        matched_keywords: Dict[str, List[str]] = {}
+
+        for specialist, keyword_weights in self._specialist_map.items():
+            specialist_score = 0.0
+            matches: List[str] = []
+            for keyword, weight in keyword_weights:
+                if keyword in joined:
+                    specialist_score += weight
+                    matches.append(keyword)
+            if specialist_score > 0:
+                scores[specialist] = specialist_score
+                matched_keywords[specialist] = matches
+
+        if not scores:
+            return DoctorRecommendation(
+                specialist="General Physician",
+                confidence=0.5,
+                reasoning=f"Symptoms ({', '.join(symptoms)}) did not match a specific specialty. A General Physician is recommended for initial evaluation.",
+            )
+
+        ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+        top_specialist, top_score = ranked[0]
+
+        # Confidence: normalize score relative to the max possible for that specialist
+        max_possible = sum(w for _, w in self._specialist_map[top_specialist])
+        confidence = min(round(top_score / max_possible, 2), 1.0)
+
+        # Build reasoning from matched keywords
+        matches_str = ", ".join(matched_keywords[top_specialist])
+        reasoning = (
+            f"Based on symptoms matching: {matches_str}. "
+            f"A {top_specialist} is recommended for further evaluation."
+        )
+
+        # Alternatives: next specialists with score > 0, excluding the top one
+        alternatives = [s for s, _ in ranked[1:4] if scores[s] > 0]
+
+        return DoctorRecommendation(
+            specialist=top_specialist,
+            confidence=confidence,
+            reasoning=reasoning,
+            alternative_specialists=alternatives,
+        )

--- a/backend/tests/test_doctor_recommendation.py
+++ b/backend/tests/test_doctor_recommendation.py
@@ -1,0 +1,112 @@
+"""Tests for the DoctorRecommendationService."""
+
+import pytest
+
+from app.services.medical_intelligence_service import DoctorRecommendationService
+
+
+@pytest.fixture
+def service():
+    return DoctorRecommendationService()
+
+
+class TestRecommend:
+    """Tests for the backwards-compatible recommend() method."""
+
+    def test_chest_pain_returns_cardiologist(self, service):
+        assert service.recommend(["chest pain"]) == "Cardiologist"
+
+    def test_skin_rash_returns_dermatologist(self, service):
+        assert service.recommend(["skin rash"]) == "Dermatologist"
+
+    def test_headache_returns_neurologist(self, service):
+        assert service.recommend(["severe headache"]) == "Neurologist"
+
+    def test_empty_symptoms_returns_general_physician(self, service):
+        assert service.recommend([]) == "General Physician"
+
+    def test_unknown_symptoms_returns_general_physician(self, service):
+        assert service.recommend(["xyz unknown"]) == "General Physician"
+
+
+class TestRecommendDetailed:
+    """Tests for the enhanced recommend_detailed() method."""
+
+    def test_returns_doctor_recommendation_model(self, service):
+        rec = service.recommend_detailed(["chest pain"])
+        assert rec.specialist == "Cardiologist"
+        assert 0.0 < rec.confidence <= 1.0
+        assert "chest pain" in rec.reasoning
+
+    def test_empty_symptoms_low_confidence(self, service):
+        rec = service.recommend_detailed([])
+        assert rec.specialist == "General Physician"
+        assert rec.confidence == 0.5
+
+    def test_multiple_symptoms_picks_highest_score(self, service):
+        rec = service.recommend_detailed(["chest pain", "heart palpitations"])
+        assert rec.specialist == "Cardiologist"
+        assert rec.confidence > 0.3
+
+    def test_alternative_specialists_populated(self, service):
+        # Shortness of breath maps to both Cardiologist and Pulmonologist
+        rec = service.recommend_detailed(["shortness of breath"])
+        all_specialists = [rec.specialist] + rec.alternative_specialists
+        assert len(all_specialists) >= 2
+
+    def test_dermatologist_confidence(self, service):
+        rec = service.recommend_detailed(["skin rash", "itchy skin", "hives"])
+        assert rec.specialist == "Dermatologist"
+        assert rec.confidence >= 0.3
+
+    def test_gastroenterologist_mapping(self, service):
+        rec = service.recommend_detailed(["abdominal pain", "bloating", "acid reflux"])
+        assert rec.specialist == "Gastroenterologist"
+
+    def test_ent_specialist_mapping(self, service):
+        rec = service.recommend_detailed(["ear pain", "hearing loss"])
+        assert rec.specialist == "ENT Specialist"
+
+    def test_ophthalmologist_mapping(self, service):
+        rec = service.recommend_detailed(["blurred vision", "eye pain"])
+        assert rec.specialist == "Ophthalmologist"
+
+    def test_psychiatrist_mapping(self, service):
+        rec = service.recommend_detailed(["anxiety", "depression", "insomnia"])
+        assert rec.specialist == "Psychiatrist"
+
+    def test_orthopedist_mapping(self, service):
+        rec = service.recommend_detailed(["joint pain", "back pain"])
+        assert rec.specialist == "Orthopedist"
+
+    def test_endocrinologist_mapping(self, service):
+        rec = service.recommend_detailed(["thyroid", "excessive thirst"])
+        assert rec.specialist == "Endocrinologist"
+
+    def test_urologist_mapping(self, service):
+        rec = service.recommend_detailed(["painful urination", "blood in urine"])
+        assert rec.specialist == "Urologist"
+
+    def test_pulmonologist_mapping(self, service):
+        rec = service.recommend_detailed(["chronic cough", "wheezing", "asthma"])
+        assert rec.specialist == "Pulmonologist"
+
+    def test_allergist_mapping(self, service):
+        rec = service.recommend_detailed(["allergic reaction", "sneezing", "watery eyes"])
+        assert rec.specialist == "Allergist"
+
+    def test_rheumatologist_mapping(self, service):
+        rec = service.recommend_detailed(["arthritis", "joint swelling", "morning stiffness"])
+        assert rec.specialist == "Rheumatologist"
+
+    def test_reasoning_contains_matched_keywords(self, service):
+        rec = service.recommend_detailed(["migraine"])
+        assert "migraine" in rec.reasoning.lower()
+
+    def test_confidence_never_exceeds_one(self, service):
+        # Even with many matching symptoms
+        rec = service.recommend_detailed([
+            "skin rash", "acne", "eczema", "psoriasis",
+            "itchy skin", "hives", "skin lesion", "mole"
+        ])
+        assert rec.confidence <= 1.0

--- a/frontend/src/features/chat/components/ChatWorkspace.tsx
+++ b/frontend/src/features/chat/components/ChatWorkspace.tsx
@@ -84,6 +84,7 @@ const response = await sendChatMessage({
         sources: response.sources || [],
         citations: response.citations || [],
         recommended_specialist: response.recommended_specialist,
+        doctor_recommendation: response.doctor_recommendation,
       }
 
       if (!activeConversationId) {
@@ -201,6 +202,7 @@ const response = await sendChatMessage({
             <SymptomAnalysisPanel
               analysis={latestAssistant?.symptom_analysis}
               specialist={latestAssistant?.recommended_specialist}
+              doctorRecommendation={latestAssistant?.doctor_recommendation}
             />
           </section>
         </div>

--- a/frontend/src/features/chat/components/SymptomAnalysisPanel.tsx
+++ b/frontend/src/features/chat/components/SymptomAnalysisPanel.tsx
@@ -1,10 +1,11 @@
-import { ActivitySquare, ShieldAlert, Stethoscope } from 'lucide-react'
+import { ActivitySquare, ShieldAlert, Stethoscope, Users } from 'lucide-react'
 import * as Accordion from '@radix-ui/react-accordion'
-import type { SymptomAnalysis } from '../types/chat'
+import type { DoctorRecommendation, SymptomAnalysis } from '../types/chat'
 
 interface SymptomAnalysisPanelProps {
   analysis?: SymptomAnalysis
   specialist?: string
+  doctorRecommendation?: DoctorRecommendation
 }
 
 function severityTone(level: SymptomAnalysis['risk_level']) {
@@ -13,7 +14,19 @@ function severityTone(level: SymptomAnalysis['risk_level']) {
   return 'text-green-700 bg-green-50 border-green-200 dark:text-green-300 dark:bg-green-500/10 dark:border-green-700/50'
 }
 
-export default function SymptomAnalysisPanel({ analysis, specialist }: SymptomAnalysisPanelProps) {
+function confidenceLabel(confidence: number): string {
+  if (confidence >= 0.8) return 'High'
+  if (confidence >= 0.5) return 'Moderate'
+  return 'Low'
+}
+
+function confidenceColor(confidence: number): string {
+  if (confidence >= 0.8) return 'bg-green-500'
+  if (confidence >= 0.5) return 'bg-yellow-500'
+  return 'bg-slate-400'
+}
+
+export default function SymptomAnalysisPanel({ analysis, specialist, doctorRecommendation }: SymptomAnalysisPanelProps) {
   if (!analysis) {
     return null
   }
@@ -48,12 +61,40 @@ export default function SymptomAnalysisPanel({ analysis, specialist }: SymptomAn
           </Accordion.Item>
         </Accordion.Root>
       )}
-      {specialist && (
+
+      {doctorRecommendation ? (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-700/50 dark:bg-blue-500/10">
+          <p className="mb-2 inline-flex items-center gap-2 text-sm font-semibold text-blue-700 dark:text-blue-300">
+            <Stethoscope className="h-4 w-4" />
+            Recommended: {doctorRecommendation.specialist}
+          </p>
+          <div className="mb-2 flex items-center gap-2">
+            <div className="h-1.5 flex-1 rounded-full bg-slate-200 dark:bg-slate-700">
+              <div
+                className={`h-1.5 rounded-full ${confidenceColor(doctorRecommendation.confidence)}`}
+                style={{ width: `${doctorRecommendation.confidence * 100}%` }}
+              />
+            </div>
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              {confidenceLabel(doctorRecommendation.confidence)} confidence
+            </span>
+          </div>
+          <p className="mb-2 text-xs text-slate-600 dark:text-slate-300">
+            {doctorRecommendation.reasoning}
+          </p>
+          {doctorRecommendation.alternative_specialists.length > 0 && (
+            <p className="inline-flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+              <Users className="h-3.5 w-3.5" />
+              Also consider: {doctorRecommendation.alternative_specialists.join(', ')}
+            </p>
+          )}
+        </div>
+      ) : specialist ? (
         <p className="inline-flex items-center gap-2 rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-700 dark:bg-blue-500/10 dark:text-blue-300">
           <Stethoscope className="h-4 w-4" />
           Recommended specialist: {specialist}
         </p>
-      )}
+      ) : null}
     </aside>
   )
 }

--- a/frontend/src/features/chat/types/chat.ts
+++ b/frontend/src/features/chat/types/chat.ts
@@ -12,6 +12,13 @@ export interface Citation {
   excerpt: string
 }
 
+export interface DoctorRecommendation {
+  specialist: string
+  confidence: number
+  reasoning: string
+  alternative_specialists: string[]
+}
+
 export interface ChatMessage {
   id: string
   role: 'user' | 'assistant'
@@ -21,6 +28,7 @@ export interface ChatMessage {
   sources?: string[]
   citations?: Citation[]
   recommended_specialist?: string
+  doctor_recommendation?: DoctorRecommendation
 }
 export interface Conversation  {
   id: string

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -21,6 +21,12 @@ export interface ChatApiResponse {
   }
   detected_language?: string
   recommended_specialist?: string
+  doctor_recommendation?: {
+    specialist: string
+    confidence: number
+    reasoning: string
+    alternative_specialists: string[]
+  }
   disclaimer?: string
 }
 


### PR DESCRIPTION
## Summary

Implements **doctor recommendation based on symptoms** as described in #33. The system now maps user symptoms to the most relevant medical specialist using a weighted scoring algorithm, replacing the previous basic keyword matching (4 specialists) with a comprehensive medical rule mapping (14 specialties, 80+ symptoms).

### What changed

- **Enhanced `DoctorRecommendationService`** with weighted symptom-to-specialist scoring
- **New `DoctorRecommendation` model** with specialist name, confidence score, reasoning, and alternative specialists
- **Updated API endpoints** (`/chat` and `/analyze-symptoms`) to return structured recommendations
- **Improved frontend panel** with confidence bar, reasoning text, and alternative specialist suggestions
- **22 unit tests** covering all specialties and edge cases

## How It Works

### Symptom-to-Specialist Mapping

Each of the 14 specialties has a list of weighted symptom keywords:

| Specialist | Example Symptoms |
|---|---|
| Cardiologist | chest pain (1.0), heart palpitations (1.0), shortness of breath (0.6) |
| Dermatologist | skin rash (1.0), acne (1.0), eczema (1.0), itchy skin (0.9) |
| Neurologist | migraine (1.0), seizure (1.0), dizziness (0.7), numbness (0.8) |
| Pulmonologist | chronic cough (1.0), wheezing (1.0), asthma (1.0) |
| Gastroenterologist | abdominal pain (1.0), acid reflux (1.0), bloating (0.8) |
| Orthopedist | joint pain (1.0), back pain (1.0), fracture (1.0) |
| ENT Specialist | ear pain (1.0), hearing loss (1.0), sore throat (0.8) |
| Ophthalmologist | blurred vision (1.0), eye pain (1.0), vision loss (1.0) |
| Endocrinologist | thyroid (1.0), diabetes (1.0), excessive thirst (0.9) |
| Psychiatrist | anxiety (1.0), depression (1.0), panic attack (1.0) |
| Urologist | painful urination (1.0), blood in urine (1.0) |
| Allergist | allergic reaction (1.0), allergy (1.0), sneezing (0.7) |
| Rheumatologist | arthritis (1.0), joint swelling (1.0), lupus (1.0) |
| Pediatrician | child (0.9), infant (1.0), baby (1.0) |

### Scoring Algorithm

1. User symptoms are matched against each specialist's keyword list
2. Matched keywords contribute their weight to that specialist's score
3. Specialists are ranked by total score
4. **Confidence** = top specialist score / max possible score for that specialist
5. Top 3 alternatives with score > 0 are included

### API Response

The `ChatResponse` now includes a `doctor_recommendation` field:

```json
{
  "doctor_recommendation": {
    "specialist": "Cardiologist",
    "confidence": 0.75,
    "reasoning": "Based on symptoms matching: chest pain, shortness of breath. A Cardiologist is recommended for further evaluation.",
    "alternative_specialists": ["Pulmonologist"]
  }
}
```

The existing `recommended_specialist` string field is preserved for backwards compatibility.

### Frontend

The SymptomAnalysisPanel now shows:
- Specialist name with stethoscope icon
- Confidence bar (color-coded: green/yellow/gray)
- Reasoning text explaining the match
- Alternative specialists to consider

## Files Changed

### Backend
- `backend/app/models/chat.py` — Added `DoctorRecommendation` Pydantic model
- `backend/app/services/medical_intelligence_service.py` — Rewritten `DoctorRecommendationService` with weighted mapping
- `backend/app/api/chat.py` — Updated both endpoints to use `recommend_detailed()`

### Frontend
- `frontend/src/features/chat/types/chat.ts` — Added `DoctorRecommendation` interface
- `frontend/src/services/chatService.ts` — Added `doctor_recommendation` to API response type
- `frontend/src/features/chat/components/SymptomAnalysisPanel.tsx` — Enhanced UI with confidence bar and alternatives
- `frontend/src/features/chat/components/ChatWorkspace.tsx` — Pass `doctorRecommendation` prop

### Tests
- `backend/tests/test_doctor_recommendation.py` — 22 unit tests (all passing)

## Test plan

- [x] All 22 unit tests pass (`pytest tests/test_doctor_recommendation.py`)
- [ ] Verify `POST /api/v1/chat` with symptom messages returns `doctor_recommendation`
- [ ] Verify `POST /api/v1/analyze-symptoms` returns correct specialist
- [ ] Verify frontend displays confidence bar and alternatives
- [ ] Verify backwards compatibility — `recommended_specialist` string still present

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)