### PR TITLE
Feature: Add local LLM provider support (LM Studio / Ollama)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,16 +10,53 @@
 # ============================================================
 
 # ------------------------------------------------------------
-# OpenAI
+# LLM Provider
 # ------------------------------------------------------------
-# Required for LLM responses and symptom analysis.
+# Which LLM backend to use.
+# Supported values:
+#   openai    — OpenAI API (default)
+#   lm-studio — Local LM Studio server (OpenAI-compatible)
+#   ollama    — Local Ollama server (OpenAI-compatible)
+LLM_PROVIDER=openai
+
+# ------------------------------------------------------------
+# OpenAI (used when LLM_PROVIDER=openai)
+# ------------------------------------------------------------
+# Your OpenAI secret key — required when LLM_PROVIDER=openai.
 # Leave blank to run in fallback (no-LLM) mode.
+#
+# When using a local provider (lm-studio or ollama) this key is
+# NOT required — those servers do not enforce authentication.
+# You can leave it blank or set it to any placeholder value.
 OPENAI_API_KEY=
 
-# OpenAI model to use for chat completions.
-# Default: gpt-3.5-turbo  (cheaper, faster)
-# Other options: gpt-4, gpt-4o
+# Model name passed to the LLM server.
+# OpenAI examples  : gpt-3.5-turbo, gpt-4, gpt-4o
+# LM Studio example: deepseek-r1-distill-llama-8b  (whatever model you loaded)
+# Ollama example   : llama3, mistral, phi3
 OPENAI_MODEL=gpt-3.5-turbo
+
+# ------------------------------------------------------------
+# Local LLM (used when LLM_PROVIDER=lm-studio or ollama)
+# ------------------------------------------------------------
+# Optional — override the base URL of the local LLM server.
+# Leave blank to use the provider default:
+#   lm-studio -> http://localhost:1234/v1
+#   ollama    -> http://localhost:11434/v1
+#
+# You only need to set this when the server is not on the default port,
+# or when running inside Docker where the host machine is reachable via
+# host.docker.internal instead of localhost (on Linux systems for example):
+#   OPENAI_BASE_URL=http://host.docker.internal:1234/v1  # LM Studio in Docker
+#   OPENAI_BASE_URL=http://host.docker.internal:11434/v1 # Ollama in Docker
+OPENAI_BASE_URL=
+
+# Request timeout in seconds for LLM API calls.
+# Leave at 0 to use the provider default:
+#   openai    -> 30s  (fast API; long waits almost always indicate an error)
+#   lm-studio -> 120s (local inference can be slow on first run)
+#   ollama    -> 120s
+LLM_TIMEOUT_SECONDS=0
 
 # ------------------------------------------------------------
 # ChromaDB (Vector Database)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ cd Ai-Healthcare-Chatbot
 
 # Configure environment
 cp .env.example .env
-# Edit .env and add your OPENAI_API_KEY (required for LLM responses)
+# Edit .env — set OPENAI_API_KEY for OpenAI, or configure a local LLM
+# (LM Studio / Ollama) — see docs/SETUP.md for details
 
 # Start backend
 ./setup.sh

--- a/backend/app/ai/translation_service.py
+++ b/backend/app/ai/translation_service.py
@@ -26,13 +26,18 @@ _LANGUAGE_TOKENS: Dict[str, list] = {
 class TranslationService:
     supported_languages = SUPPORTED_LANGUAGES
 
-    def __init__(self, api_key: str = ""):
-        self._api_key = api_key
+    def __init__(self, api_key: str = "", base_url: str = "", provider: str = "openai"):
+        self._provider = provider
+        # Local providers don't require a real API key
+        effective_key = api_key or ("local" if provider != "openai" else "")
         self._client = None
-        if api_key:
+        if effective_key:
             try:
                 from openai import OpenAI  # noqa: PLC0415
-                self._client = OpenAI(api_key=api_key)
+                kwargs: Dict[str, str] = {"api_key": effective_key}
+                if base_url:
+                    kwargs["base_url"] = base_url
+                self._client = OpenAI(**kwargs)
             except Exception:
                 pass
 

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -12,6 +12,7 @@ from ..services.medical_intelligence_service import (
 )
 from ..services.health_report_service import HealthReportService
 from ..services.rag_service import RAGService
+from .llm_provider import resolve_base_url
 from .settings import settings
 
 
@@ -25,7 +26,14 @@ def get_vector_db() -> VectorDatabase:
 
 @lru_cache
 def get_llm_service() -> LLMService:
-    return LLMService(api_key=settings.openai_api_key, model=settings.openai_model)
+    base_url = resolve_base_url(settings.llm_provider, settings.openai_base_url)
+    return LLMService(
+        api_key=settings.openai_api_key,
+        model=settings.openai_model,
+        base_url=base_url,
+        provider=settings.llm_provider,
+        timeout_seconds=settings.llm_timeout_seconds,
+    )
 
 
 @lru_cache
@@ -35,7 +43,12 @@ def get_rag_service() -> RAGService:
 
 @lru_cache
 def get_translation_service() -> TranslationService:
-    return TranslationService(api_key=settings.openai_api_key)
+    base_url = resolve_base_url(settings.llm_provider, settings.openai_base_url)
+    return TranslationService(
+        api_key=settings.openai_api_key,
+        base_url=base_url or "",
+        provider=settings.llm_provider,
+    )
 
 
 @lru_cache

--- a/backend/app/core/llm_provider.py
+++ b/backend/app/core/llm_provider.py
@@ -1,0 +1,74 @@
+"""LLM provider resolution and startup validation.
+
+This module centralises the logic for:
+- Determining the effective base URL for the configured provider
+- Validating that a local provider (LM Studio / Ollama) is reachable before
+  the application starts accepting requests
+"""
+
+import logging
+import urllib.error
+import urllib.request
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Default base URLs per provider
+_PROVIDER_DEFAULTS: dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+    "lm-studio": "http://localhost:1234/v1",
+    "ollama": "http://localhost:11434/v1",
+}
+
+# Providers that require a reachability check on startup
+_LOCAL_PROVIDERS = {"lm-studio", "ollama"}
+
+
+def resolve_base_url(provider: str, override: str = "") -> Optional[str]:
+    """Return the base URL to use for the given provider.
+
+    If *override* is non-empty it takes precedence (allows the user to point
+    to a custom host, e.g. ``host.docker.internal:1234``).
+    For ``openai`` an empty string is returned so that the OpenAI SDK uses its
+    built-in default — avoids setting the env var unnecessarily.
+    """
+    if override:
+        return override
+    if provider == "openai":
+        return None  # let the SDK use its own default
+    return _PROVIDER_DEFAULTS.get(provider)
+
+
+def validate_provider_connectivity(provider: str, base_url: str, timeout: int = 5) -> None:
+    """Ping the provider's base URL and log a clear warning if unreachable.
+
+    Only runs for local providers (``lm-studio``, ``ollama``).  For OpenAI
+    connectivity failures are surfaced naturally on the first request.
+
+    Args:
+        provider:  The value of ``LLM_PROVIDER`` (e.g. ``"lm-studio"``).
+        base_url:  The resolved base URL to check.
+        timeout:   HTTP request timeout in seconds.
+    """
+    if provider not in _LOCAL_PROVIDERS:
+        return
+
+    # Derive a simple health endpoint: strip trailing /v1 and hit the root
+    ping_url = base_url.rstrip("/")
+    if ping_url.endswith("/v1"):
+        ping_url = ping_url[:-3]
+
+    try:
+        req = urllib.request.Request(ping_url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout):
+            pass
+        logger.info("LLM provider '%s' is reachable at %s", provider, base_url)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "LLM provider '%s' does not appear to be running at %s (%s). "
+            "Requests will fail until the server is started. "
+            "See docs/SETUP.md for setup instructions.",
+            provider,
+            base_url,
+            exc,
+        )

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,11 +1,28 @@
 from pathlib import Path
+from typing import Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
-    # OpenAI
+    # LLM Provider
+    # Supported values: "openai", "lm-studio", "ollama"
+    llm_provider: Literal["openai", "lm-studio", "ollama"] = "openai"
+
+    # OpenAI / local LLM
     openai_api_key: str = ""
     openai_model: str = "gpt-3.5-turbo"
+    # Base URL for the chat-completions endpoint.
+    # Leave blank to use the provider default:
+    #   openai    -> https://api.openai.com/v1
+    #   lm-studio -> http://localhost:1234/v1
+    #   ollama    -> http://localhost:11434/v1
+    openai_base_url: str = ""
+    # Request timeout in seconds for LLM API calls.
+    # 0 means use the provider default:
+    #   openai    -> 30s  (fast API; a hang almost always means an error)
+    #   lm-studio -> 120s (local inference can be slow, especially on first run)
+    #   ollama    -> 120s
+    llm_timeout_seconds: int = 0
 
     # ChromaDB
     chroma_persist_directory: str = "./embeddings"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,15 +1,25 @@
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .api.chat import router as chat_router
 from .api.reports import router as reports_router
 from .core.logging import configure_logging
+from .core.llm_provider import resolve_base_url, validate_provider_connectivity
 from .core.settings import settings
 from .middleware.request_context import RequestContextMiddleware
 from .middleware.security import InMemoryRateLimiter, SecurityMiddleware
 
 
 configure_logging()
+logger = logging.getLogger(__name__)
+
+# Log active provider and validate connectivity for local providers
+_resolved_base_url = resolve_base_url(settings.llm_provider, settings.openai_base_url)
+logger.info("LLM provider: %s", settings.llm_provider)
+if _resolved_base_url:
+    validate_provider_connectivity(settings.llm_provider, _resolved_base_url)
 
 
 app = FastAPI(

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -42,13 +42,13 @@ class LLMService:
         Analyze the following symptoms and provide a structured assessment.
         Return your response as a JSON object with this exact structure:
 
-        {
+        {{
             "symptoms": ["list", "of", "identified", "symptoms"],
             "severity_score": <number 1-10, where 1 is mild and 10 is life-threatening>,
             "risk_level": "<low|medium|high>",
             "possible_conditions": ["list", "of", "possible", "general", "conditions"],
             "urgency_recommendation": "<recommendation for when to seek medical help>"
-        }
+        }}
 
         Guidelines for scoring:
         - Severity 1-3: Mild symptoms, can usually wait for routine care
@@ -227,7 +227,7 @@ class LLMService:
         report_prompt = """Analyze the following patient-chatbot conversation and extract health information.
 Return ONLY a JSON object with this exact structure:
 
-{
+{{
     "symptoms_detected": ["list of symptoms mentioned by the patient"],
     "possible_conditions": ["list of possible general conditions — do not diagnose, only suggest possibilities"],
     "suggested_precautions": ["list of self-care measures and precautions"],
@@ -235,7 +235,7 @@ Return ONLY a JSON object with this exact structure:
     "summary": "2-3 sentence summary of the patient health concern and key findings",
     "severity_score": <integer 1-10 representing overall severity, where 1 is mild and 10 is life-threatening>,
     "risk_level": "<low|medium|high>"
-}
+}}
 
 Severity scoring guidelines:
 - 1-3: Mild, manageable at home

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -7,17 +7,44 @@ import json
 import re
 from ..models.chat import SymptomAnalysis, RiskLevel, ReportSection
 
+# Default timeouts per provider (seconds). Applied when llm_timeout_seconds=0.
+_PROVIDER_TIMEOUTS: dict[str, int] = {
+    "openai": 30,     # Cloud API — a hang almost always means an error
+    "lm-studio": 120, # Local inference can be slow, especially on first run
+    "ollama": 120,
+}
+
+
 class LLMService:
-    def __init__(self, api_key: str, model: str = "gpt-3.5-turbo"):
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gpt-3.5-turbo",
+        base_url: Optional[str] = None,
+        provider: str = "openai",
+        timeout_seconds: int = 0,
+    ):
         self.api_key = api_key
+        self.provider = provider
         self.llm = None
-        if api_key:
-            self.llm = ChatOpenAI(
-                openai_api_key=api_key,
+
+        effective_timeout = timeout_seconds or _PROVIDER_TIMEOUTS.get(provider, 30)
+
+        # Local providers (lm-studio, ollama) expose an OpenAI-compatible API,
+        # so ChatOpenAI works for all of them — only the base_url and api_key
+        # differ.  A dummy key is used when no real key is required.
+        effective_key = api_key or ("local" if provider != "openai" else "")
+        if effective_key:
+            kwargs = dict(
+                openai_api_key=effective_key,
                 model=model,
                 temperature=0.3,  # Lower temperature for medical advice
-                max_tokens=1500
+                max_tokens=1500,
+                request_timeout=effective_timeout,
             )
+            if base_url:
+                kwargs["openai_api_base"] = base_url
+            self.llm = ChatOpenAI(**kwargs)
 
         # System prompts for different functionalities
         self.medical_system_prompt = """
@@ -92,6 +119,9 @@ class LLMService:
             json_match = re.search(r'\{.*\}', response, re.DOTALL)
             if json_match:
                 analysis_data = json.loads(json_match.group())
+                # Normalise risk_level to lowercase — some models return "LOW"/"HIGH"
+                if "risk_level" in analysis_data:
+                    analysis_data["risk_level"] = analysis_data["risk_level"].lower()
                 return SymptomAnalysis(**analysis_data)
             else:
                 # Fallback analysis

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest==9.0.3
+pydantic==2.10.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
+      args:
+        BACKEND_URL: http://backend:8000
     environment:
       BACKEND_URL: http://backend:8000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,21 @@ services:
       context: .
       dockerfile: backend/Dockerfile
     environment:
+      LLM_PROVIDER: ${LLM_PROVIDER:-openai}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_MODEL: ${OPENAI_MODEL:-gpt-3.5-turbo}
+      # Set OPENAI_BASE_URL to reach a local LLM from inside the container.
+      # On Windows/macOS Docker Desktop, host.docker.internal resolves automatically.
+      # On Linux, it is provided via extra_hosts below.
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/healthcare
       REDIS_URL: redis://redis:6379/0
       ALLOWED_ORIGINS: '["http://localhost:3000","http://127.0.0.1:3000"]'
+    # Allows the container to reach host.docker.internal on Linux.
+    # On Windows/macOS Docker Desktop this mapping already exists; the extra
+    # entry is harmless there.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - postgres
       - redis

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,15 +29,16 @@ Before you begin, make sure you have the following installed:
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 
-# Install backend dependencies
-pip install -r backend/requirements.txt
+# Install backend dependencies (production + dev/test)
+pip install -r backend/requirements.txt -r backend/requirements-dev.txt
 
 # Download the spaCy English model (required for symptom extraction)
 python -m spacy download en_core_web_sm
 
 # Configure environment variables
 cp .env.example .env
-# Edit .env — at minimum set OPENAI_API_KEY for LLM responses
+# Edit .env — set OPENAI_API_KEY for OpenAI, or configure a local LLM
+# (LM Studio / Ollama) — see docs/SETUP.md for details
 
 # Seed the ChromaDB knowledge base
 python scripts/ingest_data.py

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -7,7 +7,32 @@
 - npm 10+
 - Docker + Docker Compose (for full stack runtime)
 
-## Local Development
+---
+
+## Quick Start (Docker)
+
+The easiest way to run the full stack is with Docker Compose:
+
+```bash
+cp .env.example .env
+# Edit .env — see Environment Variables below
+docker compose up --build
+```
+
+Services started:
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:3000 |
+| Backend API | http://localhost:8000 |
+| API Docs (Swagger) | http://localhost:8000/docs |
+| PostgreSQL | localhost:5432 |
+| Redis | localhost:6379 |
+| NGINX (reverse proxy) | http://localhost:80 |
+
+---
+
+## Local Development (without Docker)
 
 1. Install dependencies:
 
@@ -21,40 +46,114 @@
 ./run_backend.sh
 ```
 
-3. Start frontend:
+3. Start frontend (new terminal):
 
 ```bash
 ./run_frontend.sh
 ```
 
+---
+
 ## Environment Variables
 
-Create `backend/.env`:
-
-```env
-OPENAI_API_KEY=
-OPENAI_MODEL=gpt-3.5-turbo
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/healthcare
-REDIS_URL=redis://localhost:6379/0
-RATE_LIMIT_PER_MINUTE=60
-REQUEST_SIZE_LIMIT_BYTES=65536
-```
-
-If `OPENAI_API_KEY` is unset, backend returns fallback guidance responses.
-
-## Containerized Full Stack
+Copy the template and edit it:
 
 ```bash
-docker compose up --build
+cp .env.example .env
 ```
 
-Services started:
+### LLM Provider
 
-- backend (`:8000`)
-- frontend (`:3000`)
-- redis (`:6379`)
-- postgres (`:5432`)
-- nginx (`:80`)
+| Variable | Default | Description |
+|---|---|---|
+| `LLM_PROVIDER` | `openai` | Which LLM backend to use: `openai`, `lm-studio`, or `ollama` |
+| `OPENAI_API_KEY` | _(empty)_ | Required when `LLM_PROVIDER=openai`. Not needed for local providers. |
+| `OPENAI_MODEL` | `gpt-3.5-turbo` | Model name passed to the LLM server. |
+| `OPENAI_BASE_URL` | _(empty)_ | Base URL for local providers. Leave blank to use the provider default. |
+| `LLM_TIMEOUT_SECONDS` | `0` | Request timeout for LLM calls. `0` uses the provider default (30s for OpenAI, 120s for local providers). |
+
+If `OPENAI_API_KEY` is unset and `LLM_PROVIDER=openai`, the backend runs in fallback mode and returns static guidance responses without calling any LLM.
+
+### Other variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATABASE_URL` | _(empty)_ | PostgreSQL connection string. Falls back to in-memory store if unset. |
+| `REDIS_URL` | _(empty)_ | Redis connection string. Falls back to in-memory cache if unset. |
+| `CACHE_TTL_SECONDS` | `300` | How long query results are cached (seconds). |
+| `RATE_LIMIT_PER_MINUTE` | `60` | Max API requests per IP per minute. |
+| `REQUEST_SIZE_LIMIT_BYTES` | `65536` | Max HTTP request body size (64 KB). |
+| `ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated list of CORS-allowed origins. |
+| `DEBUG` | `false` | Enable verbose error messages and auto-reload. |
+
+---
+
+## Local LLM Setup (LM Studio / Ollama)
+
+You can run the app entirely offline and without an OpenAI API key by using a local LLM server. Both LM Studio and Ollama expose an OpenAI-compatible API, so no other code changes are needed.
+
+### LM Studio
+
+1. Download and install [LM Studio](https://lmstudio.ai)
+2. Search for and download a model inside the app (e.g. `deepseek-r1-distill-llama-8b`)
+3. Open the **Local Server** tab and click **Start Server** (default port: `1234`)
+4. Set these variables in your `.env`:
+
+```env
+LLM_PROVIDER=lm-studio
+OPENAI_MODEL=deepseek-r1-distill-llama-8b
+OPENAI_BASE_URL=http://localhost:1234/v1
+```
+
+### Ollama
+
+1. Download and install [Ollama](https://ollama.com)
+2. Pull a model:
+
+```bash
+ollama pull llama3
+```
+
+3. Ollama starts its server automatically on port `11434`
+4. Set these variables in your `.env`:
+
+```env
+LLM_PROVIDER=ollama
+OPENAI_MODEL=llama3
+OPENAI_BASE_URL=http://localhost:11434/v1
+```
+
+### Docker networking
+
+When running inside Docker, the backend container cannot reach `localhost` on the host machine. Use `host.docker.internal` as the hostname instead:
+
+```env
+# LM Studio
+OPENAI_BASE_URL=http://host.docker.internal:1234/v1
+
+# Ollama
+OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+```
+
+This works automatically on Windows and macOS with Docker Desktop. On Linux, `docker-compose.yml` already adds the required `extra_hosts` entry so `host.docker.internal` resolves correctly.
+
+### Startup validation
+
+When `LLM_PROVIDER` is set to `lm-studio` or `ollama`, the backend pings the server on startup. If it is unreachable, a clear warning is logged — so you know immediately if the LLM server needs to be started.
+
+### Latency and timeouts
+
+Local models are significantly slower than the OpenAI API — first inference can take 30–60+ seconds depending on hardware. The backend applies a per-provider request timeout to surface errors quickly rather than hanging silently:
+
+| Provider | Default timeout |
+|---|---|
+| `openai` | 30s |
+| `lm-studio` | 120s |
+| `ollama` | 120s |
+
+Override with `LLM_TIMEOUT_SECONDS` in your `.env` if your hardware needs more or less time.
+
+---
 
 ## Data Ingestion
 
@@ -62,9 +161,16 @@ Services started:
 python scripts/ingest_data.py
 ```
 
-## CI Validation Locally
+---
+
+## Running Tests
 
 ```bash
 pytest tests/
+```
+
+Frontend checks:
+
+```bash
 cd frontend && npm run lint && npm run build
 ```

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,8 @@ FROM node:20-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules /app/node_modules
 COPY frontend /app
+ARG BACKEND_URL=http://backend:8000
+ENV BACKEND_URL=${BACKEND_URL}
 RUN npm run build
 
 FROM node:20-alpine AS runtime

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    // Local LLMs (LM Studio / Ollama) can take 60+ seconds to respond.
+    // The default Node.js proxy timeout (~30s) would drop the connection
+    // before the backend finishes. 180s gives ample headroom for slow hardware
+    // while still surfacing genuine hangs within a reasonable time.
+    proxyTimeout: 180_000,
+  },
   async rewrites() {
     const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000'
     return [

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,261 @@
+"""Tests for LLM provider support (issue #55).
+
+All external network calls and third-party SDK constructors are mocked so
+the tests run without a real LLM server or API key.
+"""
+
+from unittest.mock import MagicMock, patch
+from pydantic import ValidationError
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# resolve_base_url
+# ---------------------------------------------------------------------------
+
+from backend.app.core.llm_provider import resolve_base_url, validate_provider_connectivity
+
+
+class TestResolveBaseUrl:
+    def test_openai_no_override_returns_none(self):
+        """OpenAI provider with no override should return None (SDK default)."""
+        assert resolve_base_url("openai", "") is None
+
+    def test_openai_with_override_returns_override(self):
+        """An explicit override must be respected even for the OpenAI provider.
+
+        This supports setups like a corporate proxy or additional provider setup  through LiteLLM in front of the OpenAI API.
+        """
+        assert resolve_base_url("openai", "https://custom.openai.proxy/v1") == "https://custom.openai.proxy/v1"
+
+    def test_lm_studio_default_url(self):
+        """LM Studio defaults to localhost:1234 when no override is given."""
+        assert resolve_base_url("lm-studio", "") == "http://localhost:1234/v1"
+
+    def test_ollama_default_url(self):
+        """Ollama defaults to localhost:11434 when no override is given."""
+        assert resolve_base_url("ollama", "") == "http://localhost:11434/v1"
+
+    def test_lm_studio_override_url(self):
+        """A custom base URL (e.g. host.docker.internal for Docker) overrides the default."""
+        custom = "http://host.docker.internal:1234/v1"
+        assert resolve_base_url("lm-studio", custom) == custom
+
+    def test_ollama_override_url(self):
+        """A custom base URL (e.g. host.docker.internal for Docker) overrides the default."""
+        custom = "http://host.docker.internal:11434/v1"
+        assert resolve_base_url("ollama", custom) == custom
+
+
+# ---------------------------------------------------------------------------
+# validate_provider_connectivity
+# ---------------------------------------------------------------------------
+
+class TestValidateProviderConnectivity:
+    def test_openai_skips_check(self):
+        """OpenAI provider should never attempt a network request.
+
+        Connectivity for OpenAI is verified naturally on the first real request.
+        Pinging api.openai.com on startup would be unnecessary and slow.
+        """
+        with patch("urllib.request.urlopen") as mock_open:
+            validate_provider_connectivity("openai", "https://api.openai.com/v1")
+            mock_open.assert_not_called()
+
+    def test_local_provider_reachable_logs_info(self):
+        """When the local server is up, an INFO message is logged."""
+        with patch("urllib.request.urlopen") as mock_open:
+            mock_open.return_value.__enter__ = lambda s: s
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
+            with patch("backend.app.core.llm_provider.logger") as mock_logger:
+                validate_provider_connectivity("lm-studio", "http://localhost:1234/v1")
+                mock_logger.info.assert_called_once()
+                assert "lm-studio" in mock_logger.info.call_args.args[1]
+
+    def test_local_provider_unreachable_logs_warning(self):
+        """When the local server is down, a WARNING (not an exception) is raised.
+
+        The app should still start and serve requests — it just won't be able
+        to call the LLM until the server is running.
+        """
+        with patch("urllib.request.urlopen", side_effect=OSError("Connection refused")):
+            with patch("backend.app.core.llm_provider.logger") as mock_logger:
+                validate_provider_connectivity("ollama", "http://localhost:11434/v1")
+                mock_logger.warning.assert_called_once()
+                # args[0] is the format string; args[1] is the provider name
+                assert mock_logger.warning.call_args.args[1] == "ollama"
+
+# ---------------------------------------------------------------------------
+# LLMService — provider wiring
+# ---------------------------------------------------------------------------
+
+class TestLLMServiceProviderWiring:
+    def _make_service(self, **kwargs):
+        """Import and construct LLMService with ChatOpenAI patched out."""
+        with patch("backend.app.services.llm_service.ChatOpenAI") as MockChat:
+            from backend.app.services.llm_service import LLMService
+            svc = LLMService(**kwargs)
+            return svc, MockChat
+
+    def test_openai_provider_uses_real_key(self):
+        """OpenAI provider must pass the real API key and no custom base URL.
+
+        We intentionally omit openai_api_base for the OpenAI provider so the
+        SDK uses its own built-in default (https://api.openai.com/v1). Setting
+        it explicitly to that same URL would be redundant, and setting it to
+        anything else would silently redirect traffic away from OpenAI — so the
+        safest contract is: if provider is 'openai', never set openai_api_base.
+        """
+        with patch("backend.app.services.llm_service.ChatOpenAI") as MockChat:
+            from backend.app.services.llm_service import LLMService
+            LLMService(api_key="sk-real", model="gpt-4", provider="openai")
+            call_kwargs = MockChat.call_args.kwargs
+            assert call_kwargs["openai_api_key"] == "sk-real"
+            assert "openai_api_base" not in call_kwargs
+
+    def test_lm_studio_provider_uses_dummy_key_and_base_url(self):
+        """LM Studio does not require a real API key, so a dummy 'local' key is used.
+
+        LM Studio exposes an OpenAI-compatible API but does not enforce
+        authentication. Passing a dummy key satisfies the SDK without exposing
+        a real credential.
+        """
+        with patch("backend.app.services.llm_service.ChatOpenAI") as MockChat:
+            from backend.app.services.llm_service import LLMService
+            LLMService(
+                api_key="",
+                model="deepseek-r1-distill-llama-8b",
+                base_url="http://localhost:1234/v1",
+                provider="lm-studio",
+            )
+            call_kwargs = MockChat.call_args.kwargs
+            assert call_kwargs["openai_api_key"] == "local"
+            assert call_kwargs["openai_api_base"] == "http://localhost:1234/v1"
+
+    def test_ollama_provider_sets_base_url(self):
+        """Ollama uses an OpenAI-compatible API at its own base URL.
+
+        Like LM Studio, Ollama requires no real API key — the base URL is the
+        only configuration needed to redirect requests to the local server.
+        """
+        with patch("backend.app.services.llm_service.ChatOpenAI") as MockChat:
+            from backend.app.services.llm_service import LLMService
+            LLMService(
+                api_key="",
+                model="llama3",
+                base_url="http://localhost:11434/v1",
+                provider="ollama",
+            )
+            call_kwargs = MockChat.call_args.kwargs
+            assert call_kwargs["openai_api_base"] == "http://localhost:11434/v1"
+
+    def test_no_api_key_and_openai_provider_does_not_init_llm(self):
+        """OpenAI provider without a key must stay in fallback mode."""
+        with patch("backend.app.services.llm_service.ChatOpenAI") as MockChat:
+            from backend.app.services.llm_service import LLMService
+            svc = LLMService(api_key="", model="gpt-4", provider="openai")
+            MockChat.assert_not_called()
+            assert svc.llm is None
+
+    def test_fallback_analyze_symptoms_returns_valid_object(self):
+        """Without an LLM, analyze_symptoms should still return a SymptomAnalysis."""
+        with patch("backend.app.services.llm_service.ChatOpenAI"):
+            from backend.app.services.llm_service import LLMService
+            from backend.app.models.chat import SymptomAnalysis
+            svc = LLMService(api_key="", provider="openai")
+            result = svc.analyze_symptoms(["headache"])
+            assert isinstance(result, SymptomAnalysis)
+
+
+# ---------------------------------------------------------------------------
+# TranslationService — provider wiring
+# ---------------------------------------------------------------------------
+
+class TestTranslationServiceProviderWiring:
+    def test_openai_provider_uses_real_key(self):
+        """TranslationService passes the real API key to the OpenAI client."""
+        with patch("backend.app.ai.translation_service.TranslationService.__init__") as _:
+            pass  # just ensure import works
+
+        from unittest.mock import patch as _patch
+        with _patch("openai.OpenAI") as MockOpenAI:
+            from backend.app.ai.translation_service import TranslationService
+            TranslationService(api_key="sk-real", base_url="", provider="openai")
+            if MockOpenAI.called:
+                call_kwargs = MockOpenAI.call_args.kwargs
+                assert call_kwargs.get("api_key") == "sk-real"
+
+    def test_lm_studio_provider_uses_dummy_key(self):
+        """LM Studio does not enforce authentication, so a dummy key is used.
+
+        The OpenAI client still requires an api_key argument — 'local' is used
+        as a harmless placeholder that clearly signals no real credential is set.
+        """
+        with patch("openai.OpenAI") as MockOpenAI:
+            from backend.app.ai.translation_service import TranslationService
+            svc = TranslationService(api_key="", base_url="http://localhost:1234/v1", provider="lm-studio")
+            if MockOpenAI.called:
+                assert MockOpenAI.call_args.kwargs.get("api_key") == "local"
+
+    def test_no_key_openai_provider_has_no_client(self):
+        """OpenAI provider without a key must not create an OpenAI client."""
+        from backend.app.ai.translation_service import TranslationService
+        svc = TranslationService(api_key="", base_url="", provider="openai")
+        assert svc._client is None
+
+    def test_translate_passthrough_when_no_client(self):
+        """Without a client, text is returned unchanged."""
+        from backend.app.ai.translation_service import TranslationService
+        svc = TranslationService(api_key="", provider="openai")
+        assert svc.translate_to_english("hola", "es") == "hola"
+        assert svc.translate_from_english("hello", "es") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Settings validation
+# ---------------------------------------------------------------------------
+
+class TestSettings:
+    def test_default_provider_is_openai(self, monkeypatch):
+        """LLM_PROVIDER should default to 'openai' when not set.
+
+        env vars are cleared so a real .env file mounted in Docker does not
+        override the Pydantic default under test.
+        """
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        from backend.app.core.settings import Settings
+        s = Settings()
+        assert s.llm_provider == "openai"
+
+    def test_invalid_provider_raises(self):
+        """An unsupported provider value must raise a validation error.
+
+        The Literal type constraint on llm_provider ensures only the three
+        supported values are accepted, preventing silent misconfiguration.
+        """
+        from backend.app.core.settings import Settings
+        with pytest.raises((ValidationError, ValueError)):
+            Settings(llm_provider="unsupported-provider")
+
+    def test_lm_studio_provider_accepted(self):
+        """'lm-studio' is a valid provider value."""
+        from backend.app.core.settings import Settings
+        s = Settings(llm_provider="lm-studio")
+        assert s.llm_provider == "lm-studio"
+
+    def test_ollama_provider_accepted(self):
+        """'ollama' is a valid provider value."""
+        from backend.app.core.settings import Settings
+        s = Settings(llm_provider="ollama")
+        assert s.llm_provider == "ollama"
+
+    def test_base_url_defaults_to_empty(self, monkeypatch):
+        """OPENAI_BASE_URL should default to empty string, triggering provider defaults.
+
+        env var is cleared so a real .env file mounted in Docker does not
+        override the Pydantic default under test.
+        """
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        from backend.app.core.settings import Settings
+        s = Settings()
+        assert s.openai_base_url == ""


### PR DESCRIPTION
**Closes #55**

## Summary

Adds support for local LLM providers (LM Studio and Ollama) as drop-in alternatives to the OpenAI API. Both expose an OpenAI-compatible API, so no adapter is needed — only the base URL and authentication differ.

**Changes:**

- Add `LLM_PROVIDER` setting (`openai` | `lm-studio` | `ollama`) to `settings.py`
- Add `resolve_base_url()` — returns provider default URLs (`localhost:1234` for LM Studio, `localhost:11434` for Ollama) or a custom override
- Add startup connectivity check for local providers — logs a warning if unreachable but never raises, so the app still starts
- Update `LLMService` and `TranslationService` to accept `provider` and `base_url`; local providers use a dummy API key since they don't enforce authentication
- Wire provider config through FastAPI dependency injection (`dependencies.py`)
- Add `LLM_TIMEOUT_SECONDS` env var with per-provider defaults (30s for OpenAI, 120s for local — local inference is slow on first run)
- Add `extra_hosts: host.docker.internal:host-gateway` to `docker-compose.yml` for Linux Docker networking
- Add `backend/requirements-dev.txt` with pinned test dependencies
- Add 23 mocked unit tests covering provider URL resolution, connectivity validation, and service wiring
- Document local LLM setup in `docs/SETUP.md` and `.env.example`

Also fixes an unrelated bug: curly braces in LangChain prompt templates were not escaped, causing `KeyError` at runtime.

## Test plan

- [x]  `pytest tests/test_llm_provider.py` passes (23/23)
- [x]  App starts with `LLM_PROVIDER=openai` and responds to chat requests
- [x]  App starts with `LLM_PROVIDER=lm-studio` / `ollama` and routes requests to the local server
- [x]  App starts and logs a warning (does not crash) when local provider is not running