### PR TITLE
Feat/extend llm provider support to any provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@
 #   openai    — OpenAI API (default)
 #   lm-studio — Local LM Studio server (OpenAI-compatible)
 #   ollama    — Local Ollama server (OpenAI-compatible)
+#   litellm   — Any provider supported by LiteLLM (Anthropic, Gemini, Cohere, …)
 LLM_PROVIDER=openai
 
 # ------------------------------------------------------------
@@ -34,6 +35,7 @@ OPENAI_API_KEY=
 # OpenAI examples  : gpt-3.5-turbo, gpt-4, gpt-4o
 # LM Studio example: deepseek-r1-distill-llama-8b  (whatever model you loaded)
 # Ollama example   : llama3, mistral, phi3
+# LiteLLM examples : anthropic/claude-sonnet-4-6, gemini/gemini-2.0-flash
 OPENAI_MODEL=gpt-3.5-turbo
 
 # ------------------------------------------------------------
@@ -51,11 +53,32 @@ OPENAI_MODEL=gpt-3.5-turbo
 #   OPENAI_BASE_URL=http://host.docker.internal:11434/v1 # Ollama in Docker
 OPENAI_BASE_URL=
 
+# ------------------------------------------------------------
+# LiteLLM (used when LLM_PROVIDER=litellm)
+# ------------------------------------------------------------
+# LiteLLM lets you connect any provider by setting OPENAI_MODEL to a
+# provider-prefixed model string and supplying that provider's API key.
+# The OPENAI_API_KEY / OPENAI_BASE_URL variables are NOT used for LiteLLM.
+#
+# Anthropic (Claude):
+#   OPENAI_MODEL=anthropic/claude-sonnet-4-6
+#   ANTHROPIC_API_KEY=sk-ant-...
+#
+# Google Gemini:
+#   OPENAI_MODEL=gemini/gemini-2.0-flash
+#   GEMINI_API_KEY=...
+#
+# Full list of supported providers and model strings:
+#   https://docs.litellm.ai/docs/providers
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+
 # Request timeout in seconds for LLM API calls.
 # Leave at 0 to use the provider default:
 #   openai    -> 30s  (fast API; long waits almost always indicate an error)
 #   lm-studio -> 120s (local inference can be slow on first run)
 #   ollama    -> 120s
+#   litellm   -> 60s
 LLM_TIMEOUT_SECONDS=0
 
 # ------------------------------------------------------------

--- a/backend/app/ai/translation_service.py
+++ b/backend/app/ai/translation_service.py
@@ -26,20 +26,32 @@ _LANGUAGE_TOKENS: Dict[str, list] = {
 class TranslationService:
     supported_languages = SUPPORTED_LANGUAGES
 
-    def __init__(self, api_key: str = "", base_url: str = "", provider: str = "openai"):
+    def __init__(self, api_key: str = "", base_url: str = "", provider: str = "openai", model: str = "gpt-3.5-turbo"):
         self._provider = provider
-        # Local providers don't require a real API key
-        effective_key = api_key or ("local" if provider != "openai" else "")
+        self._model = model
         self._client = None
-        if effective_key:
-            try:
-                from openai import OpenAI  # noqa: PLC0415
-                kwargs: Dict[str, str] = {"api_key": effective_key}
-                if base_url:
-                    kwargs["base_url"] = base_url
-                self._client = OpenAI(**kwargs)
-            except Exception:
-                pass
+        self._litellm = None
+
+        if provider == "litellm":
+            # LiteLLM handles routing internally; no OpenAI client needed.
+            # Provider-specific API keys are read from env vars by LiteLLM.
+            # Only enable it if the required key is present — otherwise leave
+            # _litellm as None so translation falls back to passthrough.
+            import litellm  # noqa: PLC0415
+            if litellm.validate_environment(model).get("keys_in_environment"):
+                self._litellm = litellm
+        else:
+            # Local providers don't require a real API key
+            effective_key = api_key or ("local" if provider != "openai" else "")
+            if effective_key:
+                try:
+                    from openai import OpenAI  # noqa: PLC0415
+                    kwargs: Dict[str, str] = {"api_key": effective_key}
+                    if base_url:
+                        kwargs["base_url"] = base_url
+                    self._client = OpenAI(**kwargs)
+                except Exception:
+                    pass
 
     def detect_language(self, text: str) -> str:
         stripped = text.strip().lower()
@@ -53,14 +65,33 @@ class TranslationService:
             return max(scores, key=lambda k: scores[k])
         return "en"
 
+    def _chat_completion(self, messages: list, max_tokens: int) -> str:
+        """Call the configured provider and return the assistant message content."""
+        if self._litellm:
+            result = self._litellm.completion(
+                model=self._model,
+                messages=messages,
+                temperature=0,
+                max_tokens=max_tokens,
+            )
+            return result.choices[0].message.content.strip()
+        if self._client:
+            result = self._client.chat.completions.create(
+                model=self._model,
+                messages=messages,
+                temperature=0,
+                max_tokens=max_tokens,
+            )
+            return result.choices[0].message.content.strip()
+        return ""
+
     def translate_to_english(self, text: str, source_lang: str) -> str:
         if source_lang == "en" or not text.strip():
             return text
-        if self._client:
+        if self._litellm or self._client:
             try:
                 lang_name = self.supported_languages.get(source_lang, source_lang)
-                result = self._client.chat.completions.create(
-                    model="gpt-3.5-turbo",
+                return self._chat_completion(
                     messages=[
                         {
                             "role": "system",
@@ -71,10 +102,8 @@ class TranslationService:
                         },
                         {"role": "user", "content": text},
                     ],
-                    temperature=0,
                     max_tokens=600,
                 )
-                return result.choices[0].message.content.strip()
             except Exception:
                 pass
         return text
@@ -82,11 +111,10 @@ class TranslationService:
     def translate_from_english(self, text: str, target_lang: str) -> str:
         if target_lang == "en" or not text.strip():
             return text
-        if self._client:
+        if self._litellm or self._client:
             try:
                 lang_name = self.supported_languages.get(target_lang, target_lang)
-                result = self._client.chat.completions.create(
-                    model="gpt-3.5-turbo",
+                return self._chat_completion(
                     messages=[
                         {
                             "role": "system",
@@ -97,10 +125,8 @@ class TranslationService:
                         },
                         {"role": "user", "content": text},
                     ],
-                    temperature=0,
                     max_tokens=2000,
                 )
-                return result.choices[0].message.content.strip()
             except Exception:
                 pass
         return text

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -48,6 +48,7 @@ def get_translation_service() -> TranslationService:
         api_key=settings.openai_api_key,
         base_url=base_url or "",
         provider=settings.llm_provider,
+        model=settings.openai_model,
     )
 
 

--- a/backend/app/core/llm_provider.py
+++ b/backend/app/core/llm_provider.py
@@ -13,11 +13,12 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# Default base URLs per provider
-_PROVIDER_DEFAULTS: dict[str, str] = {
+# Default base URLs per provider (None = let the SDK use its own default)
+_PROVIDER_DEFAULTS: dict[str, Optional[str]] = {
     "openai": "https://api.openai.com/v1",
     "lm-studio": "http://localhost:1234/v1",
     "ollama": "http://localhost:11434/v1",
+    "litellm": None,  # LiteLLM routes internally via the model string; no base URL needed
 }
 
 # Providers that require a reachability check on startup

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,12 +1,25 @@
 from pathlib import Path
 from typing import Literal
 
+from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Path to the .env file, shared by load_dotenv (below) and pydantic-settings.
+_ENV_FILE = Path(__file__).resolve().parents[1] / ".env"
+
+# Load the .env file into os.environ as well. pydantic-settings only maps the
+# variables declared on Settings; libraries that read os.environ directly —
+# notably LiteLLM looking up ANTHROPIC_API_KEY / GEMINI_API_KEY / etc. — need
+# the values exported to the process environment too.
+# override=False keeps real environment variables (e.g. those set by Docker)
+# authoritative over the .env file.
+load_dotenv(_ENV_FILE, override=False)
+
 
 class Settings(BaseSettings):
     # LLM Provider
-    # Supported values: "openai", "lm-studio", "ollama"
-    llm_provider: Literal["openai", "lm-studio", "ollama"] = "openai"
+    # Supported values: "openai", "lm-studio", "ollama", "litellm"
+    llm_provider: Literal["openai", "lm-studio", "ollama", "litellm"] = "openai"
 
     # OpenAI / local LLM
     openai_api_key: str = ""
@@ -16,12 +29,14 @@ class Settings(BaseSettings):
     #   openai    -> https://api.openai.com/v1
     #   lm-studio -> http://localhost:1234/v1
     #   ollama    -> http://localhost:11434/v1
+    #   litellm   -> not used (LiteLLM routes internally via the model string)
     openai_base_url: str = ""
     # Request timeout in seconds for LLM API calls.
     # 0 means use the provider default:
     #   openai    -> 30s  (fast API; a hang almost always means an error)
     #   lm-studio -> 120s (local inference can be slow, especially on first run)
     #   ollama    -> 120s
+    #   litellm   -> 60s
     llm_timeout_seconds: int = 0
 
     # ChromaDB
@@ -45,7 +60,7 @@ class Settings(BaseSettings):
     cache_ttl_seconds: int = 300
 
     model_config = SettingsConfigDict(
-        env_file=str(Path(__file__).resolve().parents[1] / ".env"),
+        env_file=str(_ENV_FILE),
         case_sensitive=False,
     )
 

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -4,14 +4,18 @@ from langchain.schema import StrOutputParser
 from langchain.schema.runnable import RunnablePassthrough
 from typing import List, Optional
 import json
+import logging
 import re
 from ..models.chat import SymptomAnalysis, RiskLevel, ReportSection
+
+logger = logging.getLogger(__name__)
 
 # Default timeouts per provider (seconds). Applied when llm_timeout_seconds=0.
 _PROVIDER_TIMEOUTS: dict[str, int] = {
     "openai": 30,     # Cloud API — a hang almost always means an error
     "lm-studio": 120, # Local inference can be slow, especially on first run
     "ollama": 120,
+    "litellm": 60,    # Cloud API via LiteLLM proxy; generous default for slower providers
 }
 
 
@@ -30,21 +34,48 @@ class LLMService:
 
         effective_timeout = timeout_seconds or _PROVIDER_TIMEOUTS.get(provider, 30)
 
-        # Local providers (lm-studio, ollama) expose an OpenAI-compatible API,
-        # so ChatOpenAI works for all of them — only the base_url and api_key
-        # differ.  A dummy key is used when no real key is required.
-        effective_key = api_key or ("local" if provider != "openai" else "")
-        if effective_key:
-            kwargs = dict(
-                openai_api_key=effective_key,
-                model=model,
-                temperature=0.3,  # Lower temperature for medical advice
-                max_tokens=1500,
-                request_timeout=effective_timeout,
-            )
-            if base_url:
-                kwargs["openai_api_base"] = base_url
-            self.llm = ChatOpenAI(**kwargs)
+        if provider == "litellm":
+            # LiteLLM routes to any provider (Anthropic, Gemini, …) via the model
+            # string (e.g. "anthropic/claude-sonnet-4-6"). Provider-specific API
+            # keys are read from env vars automatically by the LiteLLM library.
+            #
+            # Only build the model if the required key is present. Otherwise
+            # leave self.llm as None so the service degrades to fallback mode —
+            # consistent with the OpenAI provider when OPENAI_API_KEY is unset.
+            import litellm  # noqa: PLC0415
+            env_status = litellm.validate_environment(model)
+            if env_status.get("keys_in_environment"):
+                from langchain_community.chat_models import ChatLiteLLM  # noqa: PLC0415
+                self.llm = ChatLiteLLM(
+                    model=model,
+                    temperature=0.3,
+                    max_tokens=1500,
+                    request_timeout=effective_timeout,
+                )
+            else:
+                logger.warning(
+                    "LLM provider 'litellm' selected for model '%s' but required "
+                    "API key(s) are missing from the environment: %s. Running in "
+                    "fallback mode. See docs/SETUP.md for setup instructions.",
+                    model,
+                    env_status.get("missing_keys"),
+                )
+        else:
+            # Local providers (lm-studio, ollama) expose an OpenAI-compatible API,
+            # so ChatOpenAI works for all of them — only the base_url and api_key
+            # differ.  A dummy key is used when no real key is required.
+            effective_key = api_key or ("local" if provider != "openai" else "")
+            if effective_key:
+                kwargs = dict(
+                    openai_api_key=effective_key,
+                    model=model,
+                    temperature=0.3,  # Lower temperature for medical advice
+                    max_tokens=1500,
+                    request_timeout=effective_timeout,
+                )
+                if base_url:
+                    kwargs["openai_api_base"] = base_url
+                self.llm = ChatOpenAI(**kwargs)
 
         # System prompts for different functionalities
         self.medical_system_prompt = """

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,5 @@ spacy==3.8.2
 reportlab==4.2.5
 opencv-python==4.9.0.80
 mediapipe==0.10.9
+litellm>=1.0.0
+langchain-community>=0.0.20,<0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
+      args:
+        BACKEND_URL: http://backend:8000
     environment:
       BACKEND_URL: http://backend:8000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+    # Load the project .env into the container so provider-specific API keys
+    # (ANTHROPIC_API_KEY, GEMINI_API_KEY, …) used by LiteLLM are available.
+    # The explicit `environment:` entries below still take precedence.
+    env_file:
+      - .env
     environment:
       LLM_PROVIDER: ${LLM_PROVIDER:-openai}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -66,7 +66,7 @@ cp .env.example .env
 
 | Variable | Default | Description |
 |---|---|---|
-| `LLM_PROVIDER` | `openai` | Which LLM backend to use: `openai`, `lm-studio`, or `ollama` |
+| `LLM_PROVIDER` | `openai` | Which LLM backend to use: `openai`, `lm-studio`, `ollama`, or `litellm` |
 | `OPENAI_API_KEY` | _(empty)_ | Required when `LLM_PROVIDER=openai`. Not needed for local providers. |
 | `OPENAI_MODEL` | `gpt-3.5-turbo` | Model name passed to the LLM server. |
 | `OPENAI_BASE_URL` | _(empty)_ | Base URL for local providers. Leave blank to use the provider default. |
@@ -123,6 +123,32 @@ OPENAI_MODEL=llama3
 OPENAI_BASE_URL=http://localhost:11434/v1
 ```
 
+### LiteLLM (Anthropic, Gemini, Cohere, and 100+ others)
+
+LiteLLM is a unified translation layer that makes any provider speak the OpenAI API. Set `LLM_PROVIDER=litellm` and use a provider-prefixed model string in `OPENAI_MODEL`.
+
+**Anthropic Claude:**
+
+```env
+LLM_PROVIDER=litellm
+OPENAI_MODEL=anthropic/claude-sonnet-4-6
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**Google Gemini:**
+
+```env
+LLM_PROVIDER=litellm
+OPENAI_MODEL=gemini/gemini-2.0-flash
+GEMINI_API_KEY=...
+```
+
+LiteLLM reads the provider-specific API key from environment variables automatically — no `OPENAI_API_KEY` or `OPENAI_BASE_URL` needed.
+
+For a full list of supported providers and model string formats, see the [LiteLLM provider docs](https://docs.litellm.ai/docs/providers).
+
+---
+
 ### Docker networking
 
 When running inside Docker, the backend container cannot reach `localhost` on the host machine. Use `host.docker.internal` as the hostname instead:
@@ -150,6 +176,7 @@ Local models are significantly slower than the OpenAI API — first inference ca
 | `openai` | 30s |
 | `lm-studio` | 120s |
 | `ollama` | 120s |
+| `litellm` | 60s |
 
 Override with `LLM_TIMEOUT_SECONDS` in your `.env` if your hardware needs more or less time.
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,8 @@ FROM node:20-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules /app/node_modules
 COPY frontend /app
+ARG BACKEND_URL=http://backend:8000
+ENV BACKEND_URL=${BACKEND_URL}
 RUN npm run build
 
 FROM node:20-alpine AS runtime

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -259,3 +259,122 @@ class TestSettings:
         from backend.app.core.settings import Settings
         s = Settings()
         assert s.openai_base_url == ""
+
+    def test_litellm_provider_accepted(self):
+        """'litellm' is a valid provider value."""
+        from backend.app.core.settings import Settings
+        s = Settings(llm_provider="litellm")
+        assert s.llm_provider == "litellm"
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM provider — resolve_base_url and LLMService wiring
+# ---------------------------------------------------------------------------
+
+class TestLiteLLMProviderSupport:
+    def test_resolve_base_url_litellm_returns_none(self):
+        """LiteLLM provider should return None — routing is handled internally by the library."""
+        assert resolve_base_url("litellm", "") is None
+
+    def test_resolve_base_url_litellm_ignores_override(self):
+        """An explicit base URL override is passed through even for litellm.
+
+        This allows advanced users to point at a self-hosted LiteLLM proxy.
+        """
+        assert resolve_base_url("litellm", "http://my-litellm-proxy/v1") == "http://my-litellm-proxy/v1"
+
+    def test_litellm_provider_skips_connectivity_check(self):
+        """LiteLLM is a cloud routing library — no startup ping should be performed."""
+        with patch("urllib.request.urlopen") as mock_open:
+            validate_provider_connectivity("litellm", "")
+            mock_open.assert_not_called()
+
+    @staticmethod
+    def _mock_litellm(keys_in_environment: bool = True):
+        """Build a fake `litellm` module whose validate_environment is controllable.
+
+        validate_environment reports whether the provider's API key is present;
+        the service code uses it to decide between live mode and fallback mode.
+        """
+        mock = MagicMock()
+        mock.validate_environment.return_value = {
+            "keys_in_environment": keys_in_environment,
+            "missing_keys": [] if keys_in_environment else ["ANTHROPIC_API_KEY"],
+        }
+        return mock
+
+    def test_llm_service_litellm_uses_chat_litellm(self):
+        """With a key present, LLMService must instantiate ChatLiteLLM, not ChatOpenAI."""
+        with patch("backend.app.services.llm_service.ChatOpenAI") as MockChatOpenAI, \
+             patch("langchain_community.chat_models.ChatLiteLLM") as MockChatLiteLLM, \
+             patch.dict("sys.modules", {"litellm": self._mock_litellm(keys_in_environment=True)}):
+            from backend.app.services.llm_service import LLMService
+            svc = LLMService(
+                api_key="",
+                model="anthropic/claude-sonnet-4-6",
+                provider="litellm",
+            )
+            MockChatOpenAI.assert_not_called()
+            assert svc.llm is not None
+
+    def test_llm_service_litellm_passes_model_string(self):
+        """ChatLiteLLM must receive the full provider-prefixed model string."""
+        with patch("langchain_community.chat_models.ChatLiteLLM") as MockChatLiteLLM, \
+             patch.dict("sys.modules", {"litellm": self._mock_litellm(keys_in_environment=True)}):
+            from backend.app.services.llm_service import LLMService
+            LLMService(
+                api_key="",
+                model="anthropic/claude-sonnet-4-6",
+                provider="litellm",
+            )
+            call_kwargs = MockChatLiteLLM.call_args.kwargs
+            assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+
+    def test_llm_service_litellm_missing_key_falls_back(self):
+        """Without the required API key, LLMService must stay in fallback mode (llm is None).
+
+        This mirrors the OpenAI provider behaviour when OPENAI_API_KEY is unset,
+        so a misconfigured litellm provider degrades gracefully instead of
+        crashing on the first request.
+        """
+        with patch("langchain_community.chat_models.ChatLiteLLM") as MockChatLiteLLM, \
+             patch.dict("sys.modules", {"litellm": self._mock_litellm(keys_in_environment=False)}):
+            from backend.app.services.llm_service import LLMService
+            svc = LLMService(
+                api_key="",
+                model="anthropic/claude-sonnet-4-6",
+                provider="litellm",
+            )
+            MockChatLiteLLM.assert_not_called()
+            assert svc.llm is None
+
+    def test_translation_service_litellm_uses_litellm_completion(self):
+        """TranslationService must use litellm.completion(), not the OpenAI client."""
+        mock_litellm = self._mock_litellm(keys_in_environment=True)
+        mock_litellm.completion.return_value.choices[0].message.content = "Hello"
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            from backend.app.ai.translation_service import TranslationService
+            svc = TranslationService(
+                api_key="",
+                provider="litellm",
+                model="anthropic/claude-sonnet-4-6",
+            )
+            result = svc.translate_to_english("Hola", "es")
+            assert result == "Hello"
+            mock_litellm.completion.assert_called_once()
+            assert mock_litellm.completion.call_args.kwargs["model"] == "anthropic/claude-sonnet-4-6"
+
+    def test_translation_service_litellm_no_openai_client(self):
+        """TranslationService with litellm provider must not create an OpenAI client."""
+        with patch.dict("sys.modules", {"litellm": self._mock_litellm(keys_in_environment=True)}):
+            from backend.app.ai.translation_service import TranslationService
+            svc = TranslationService(api_key="", provider="litellm", model="anthropic/claude-sonnet-4-6")
+            assert svc._client is None
+
+    def test_translation_service_litellm_missing_key_passthrough(self):
+        """Without the required API key, TranslationService returns text unchanged."""
+        with patch.dict("sys.modules", {"litellm": self._mock_litellm(keys_in_environment=False)}):
+            from backend.app.ai.translation_service import TranslationService
+            svc = TranslationService(api_key="", provider="litellm", model="anthropic/claude-sonnet-4-6")
+            assert svc._litellm is None
+            assert svc.translate_to_english("Hola", "es") == "Hola"


### PR DESCRIPTION
## Summary

Adds `litellm` as a fourth `LLM_PROVIDER`, routing requests through the
[LiteLLM](https://github.com/BerriAI/litellm) library. This unlocks any
LiteLLM-supported provider — Anthropic, Gemini, Cohere, and 100+ others —
without changing the service layer.

Closes #90 

## What changed

- `settings.py` / `llm_provider.py` — `litellm` accepted as a provider; no
  base URL needed (LiteLLM routes via the model string).
- `llm_service.py` — uses `ChatLiteLLM` instead of `ChatOpenAI` for `litellm`;
  existing chains reused unchanged.
- `translation_service.py` — calls `litellm.completion()` via a shared helper.
- `settings.py` + `docker-compose.yml` — `.env` is exported to the environment
  (`load_dotenv` / `env_file`) so LiteLLM finds provider keys.
- Falls back to no-LLM mode if the required key is missing, via
  `litellm.validate_environment()`.
- `requirements.txt`, `.env.example`, `docs/SETUP.md` updated.

## Testing

- 10 new unit tests; full suite **33 passed**.
- Verified in Docker: logs confirm LiteLLM routes correctly to `gemini` and
  picks up the API key from the environment.

## ⚠️ Unrelated: build broken on `master`

The backend image currently fails to build — `requirements.txt` pins
`mediapipe==0.10.9` (added in #82), which has been **yanked from PyPI**. I
bumped it to `0.10.14` locally to test this PR; that change is **not included
here**. Suggest a separate issue/PR for the `mediapipe` pin.